### PR TITLE
Static files aren't versioned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/
 node_modules/
 
 .idea
+
+rev-manifest.json

--- a/gulpfile.litcoffee
+++ b/gulpfile.litcoffee
@@ -65,6 +65,9 @@ Style checkers:
     browserSync = require('browser-sync').create()
     reload      = browserSync.reload
 
+Utils
+
+    clean = require 'gulp-clean'
 Publish static assets to AWS S3 bucket and load AWS IAM credentials:
 
     s3 = require 'gulp-s3'
@@ -90,7 +93,7 @@ Tasks
 The **default** task builds all static assets, runs local server at :3000
 and watches for changes. Use **build** task for one-time build.
 
-    gulp.task 'build', ['html', 'css', 'files']
+    gulp.task 'build', ['clean','html', 'css', 'files']
     gulp.task 'default', ['serve']
 
 **debug-mode** -- Enables debug mode: Minification is disabled, source maps are
@@ -150,6 +153,12 @@ gulp-sass, gulp-autprefixer or gulp-sourcemaps (dunno which one). See
       gulp.src Source.files
       .pipe gulp.dest BuildRoot
 
+
+**clean** -- Clean the build dir
+
+    gulp.task 'clean', ->
+      gulp.src BuildRoot
+      .pipe clean()
 
 **serve** -- Start serving static files and watch for file changes.
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.2.0",
     "gulp-bytediff": "^0.2.1",
+    "gulp-clean": "^0.3.1",
     "gulp-coffeelint": "^0.4.0",
     "gulp-if-else": "^1.0.3",
     "gulp-jade": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,17 +14,20 @@
     "gulp": "^3.8.11",
     "gulp-autoprefixer": "^2.2.0",
     "gulp-bytediff": "^0.2.1",
-    "gulp-clean": "^0.3.1",
     "gulp-coffeelint": "^0.4.0",
     "gulp-if-else": "^1.0.3",
     "gulp-jade": "^1.0.0",
     "gulp-minify-css": "^1.1.1",
     "gulp-minify-html": "^1.0.2",
+    "gulp-rev": "^3.0.1",
+    "gulp-rev-collector": "^0.1.4",
+    "gulp-rimraf": "^0.1.1",
     "gulp-s3": "^0.3.0",
     "gulp-sass": "^2.0.0",
     "gulp-scss-lint": "^0.1.12",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.4",
-    "lazypipe": "^0.2.3"
+    "lazypipe": "^0.2.3",
+    "run-sequence": "^1.1.0"
   }
 }


### PR DESCRIPTION
Static files should be versioned so browsers load new files immediately (for now we could drop the cache timeout?)

Could be solved using these libraries (see the bottom of gulp-rev page for more packages):
https://www.npmjs.com/package/gulp-rev
https://github.com/jamesknelson/gulp-rev-replace
